### PR TITLE
fix: use `configDir` for `save`

### DIFF
--- a/main.go
+++ b/main.go
@@ -250,7 +250,7 @@ func (cfg *Config) save(profile string) error {
 	if cfg.tempRelay {
 		return nil
 	}
-	dir, err := os.UserConfigDir()
+	dir, err := configDir()
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -69,7 +69,6 @@ func configDir() (string, error) {
 		return filepath.Join(dir, ".config"), nil
 	default:
 		return os.UserConfigDir()
-
 	}
 }
 


### PR DESCRIPTION
On macOS, it still tries to read the configuration from `~/Library/Application Support/algia/config.json`. #4 didn't fully cover the occurence of `os.UserConfigDir` in `save` function, so I've replaced it by `configDir`.