### PR TITLE
Support NIP-26 delegated event signing

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -187,7 +187,7 @@ func doChannelCreate(cCtx *cli.Context) error {
 	}
 	cfg := cCtx.App.Metadata["config"].(*Config)
 
-	sk, pub, err := getSkAndPub(cfg)
+	_, pub, err := getSkAndPub(cfg)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func doChannelCreate(cCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := ev.Sign(sk); err != nil {
+	if err := cfg.signEvent(ev); err != nil {
 		return err
 	}
 
@@ -386,7 +386,7 @@ func doChannelPost(cCtx *cli.Context) error {
 
 	cfg := cCtx.App.Metadata["config"].(*Config)
 
-	sk, pub, err := getSkAndPub(cfg)
+	_, pub, err := getSkAndPub(cfg)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func doChannelPost(cCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := ev.Sign(sk); err != nil {
+	if err := cfg.signEvent(ev); err != nil {
 		return err
 	}
 

--- a/dm.go
+++ b/dm.go
@@ -357,7 +357,7 @@ func doDMPost(cCtx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := ev.Sign(sk); err != nil {
+		if err := cfg.signEvent(&ev); err != nil {
 			return err
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mattn/algia
 go 1.24.1
 
 require (
+	github.com/btcsuite/btcd/btcec/v2 v2.3.6
 	github.com/fatih/color v1.18.0
 	github.com/mark3labs/mcp-go v0.43.1
 	github.com/mdp/qrterminal/v3 v3.2.1
@@ -15,7 +16,6 @@ require (
 	github.com/ImVexed/fasturl v0.0.0-20230304231329-4e41488060f3 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.6 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect

--- a/list.go
+++ b/list.go
@@ -449,7 +449,7 @@ type listAddArg struct {
 }
 
 func callListAdd(arg *listAddArg) error {
-	sk, pub, err := getSkAndPub(arg.cfg)
+	_, pub, err := getSkAndPub(arg.cfg)
 	if err != nil {
 		return err
 	}
@@ -499,7 +499,7 @@ func callListAdd(arg *listAddArg) error {
 		ev.Tags = ev.Tags.AppendUnique(tag)
 	}
 
-	if err := ev.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(&ev); err != nil {
 		return err
 	}
 
@@ -546,7 +546,7 @@ type listRemoveArg struct {
 }
 
 func callListRemove(arg *listRemoveArg) error {
-	sk, pub, err := getSkAndPub(arg.cfg)
+	_, pub, err := getSkAndPub(arg.cfg)
 	if err != nil {
 		return err
 	}
@@ -603,7 +603,7 @@ func callListRemove(arg *listRemoveArg) error {
 		ev.Tags = append(ev.Tags, tag)
 	}
 
-	if err := ev.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(&ev); err != nil {
 		return err
 	}
 
@@ -649,7 +649,7 @@ type listDeleteArg struct {
 }
 
 func callListDelete(arg *listDeleteArg) error {
-	sk, pub, err := getSkAndPub(arg.cfg)
+	_, pub, err := getSkAndPub(arg.cfg)
 	if err != nil {
 		return err
 	}
@@ -672,7 +672,7 @@ func callListDelete(arg *listDeleteArg) error {
 		}
 	}
 
-	if err := ev.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(&ev); err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ type Config struct {
 	Emojis         map[string]string `json:"emojis"`
 	NwcURI         string            `json:"nwc-uri"`
 	FileServers    []fileServer      `json:"file-servers"`
+	Delegation     *Delegation       `json:"delegation,omitempty"`
 	profiles       map[string]Profile
 	pool           *nostr.SimplePool
 	profileChanged bool
@@ -605,7 +606,8 @@ func (cfg *Config) PrintEvents(evs []*nostr.Event, followsMap map[string]Profile
 	}
 
 	for _, ev := range evs {
-		profile, err := cfg.GetProfile(ev.PubKey)
+		pubkey, delegated := delegationDisplayPubKey(ev)
+		profile, err := cfg.GetProfile(pubkey)
 
 		fmt.Print(ev.CreatedAt.Time().Format("2006-01-02T15:04:05") + " ")
 		if err == nil {
@@ -613,11 +615,15 @@ func (cfg *Config) PrintEvents(evs []*nostr.Event, followsMap map[string]Profile
 			fmt.Print(profile.Name)
 		} else {
 			color.Set(color.FgRed)
-			if pk, err := nip19.EncodePublicKey(ev.PubKey); err == nil {
+			if pk, err := nip19.EncodePublicKey(pubkey); err == nil {
 				fmt.Print(pk)
 			} else {
-				fmt.Print(ev.PubKey)
+				fmt.Print(pubkey)
 			}
+		}
+		if delegated {
+			color.Set(color.FgHiBlack)
+			fmt.Print(" (delegated)")
 		}
 		color.Set(color.Reset)
 		fmt.Print(": ")
@@ -654,17 +660,22 @@ func (cfg *Config) PrintEvent(ev *nostr.Event, j, extra bool) {
 
 	fmt.Print(ev.CreatedAt.Time().Format("2006-01-02T15:04:05") + " ")
 
+	pubkey, delegated := delegationDisplayPubKey(ev)
 	// Check cache only, don't fetch
-	if profile, err := cfg.GetProfile(ev.PubKey); err == nil {
+	if profile, err := cfg.GetProfile(pubkey); err == nil {
 		color.Set(color.FgHiRed)
 		fmt.Print(profile.Name)
 	} else {
 		color.Set(color.FgRed)
-		if pk, err := nip19.EncodePublicKey(ev.PubKey); err == nil {
+		if pk, err := nip19.EncodePublicKey(pubkey); err == nil {
 			fmt.Print(pk)
 		} else {
-			fmt.Print(ev.PubKey)
+			fmt.Print(pubkey)
 		}
+	}
+	if delegated {
+		color.Set(color.FgHiBlack)
+		fmt.Print(" (delegated)")
 	}
 	color.Set(color.Reset)
 	fmt.Print(": ")
@@ -1017,7 +1028,7 @@ func doReport(cCtx *cli.Context) error {
 	}
 
 	// Sign
-	if err := report.Sign(sk); err != nil {
+	if err := cfg.signEvent(report); err != nil {
 		return err
 	}
 
@@ -1329,6 +1340,7 @@ func main() {
 				Action:    doReport,
 			},
 			fileCommand(),
+			delegationCommand(),
 		},
 		Before: func(cCtx *cli.Context) error {
 			switch cCtx.Args().Get(0) {

--- a/nip26.go
+++ b/nip26.go
@@ -1,0 +1,387 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/nbd-wtf/go-nostr/nip19"
+	"github.com/urfave/cli/v2"
+)
+
+// Delegation is
+type Delegation struct {
+	Delegator  string `json:"delegator"`
+	Conditions string `json:"conditions"`
+	Token      string `json:"token"`
+}
+
+type delegationConditions struct {
+	kinds  []int
+	after  int64
+	before int64
+}
+
+func parseDelegationConditions(q string) (*delegationConditions, error) {
+	c := &delegationConditions{}
+	for _, cond := range strings.Split(q, "&") {
+		switch {
+		case strings.HasPrefix(cond, "kind="):
+			kind, err := strconv.Atoi(cond[len("kind="):])
+			if err != nil {
+				return nil, fmt.Errorf("invalid delegation condition %q", cond)
+			}
+			c.kinds = append(c.kinds, kind)
+		case strings.HasPrefix(cond, "created_at>"):
+			ts, err := strconv.ParseInt(cond[len("created_at>"):], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid delegation condition %q", cond)
+			}
+			c.after = ts
+		case strings.HasPrefix(cond, "created_at<"):
+			ts, err := strconv.ParseInt(cond[len("created_at<"):], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid delegation condition %q", cond)
+			}
+			c.before = ts
+		default:
+			return nil, fmt.Errorf("unsupported delegation condition %q", cond)
+		}
+	}
+	return c, nil
+}
+
+func (c *delegationConditions) allow(kind int, createdAt int64) error {
+	if len(c.kinds) > 0 {
+		found := false
+		for _, k := range c.kinds {
+			if k == kind {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("delegation does not permit kind=%d", kind)
+		}
+	}
+	if c.after != 0 && createdAt <= c.after {
+		return fmt.Errorf("delegation is not valid before %v", time.Unix(c.after, 0))
+	}
+	if c.before != 0 && createdAt >= c.before {
+		return fmt.Errorf("delegation expired at %v", time.Unix(c.before, 0))
+	}
+	return nil
+}
+
+func delegationHash(delegateePub, conditions string) []byte {
+	h := sha256.Sum256([]byte("nostr:delegation:" + delegateePub + ":" + conditions))
+	return h[:]
+}
+
+func createDelegationToken(delegatorSk, delegateePub, conditions string) (string, error) {
+	b, err := hex.DecodeString(delegatorSk)
+	if err != nil {
+		return "", err
+	}
+	priv, _ := btcec.PrivKeyFromBytes(b)
+	sig, err := schnorr.Sign(priv, delegationHash(delegateePub, conditions))
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(sig.Serialize()), nil
+}
+
+func verifyDelegationToken(delegatorPub, delegateePub, conditions, token string) bool {
+	pb, err := hex.DecodeString(delegatorPub)
+	if err != nil {
+		return false
+	}
+	pub, err := schnorr.ParsePubKey(pb)
+	if err != nil {
+		return false
+	}
+	sb, err := hex.DecodeString(token)
+	if err != nil {
+		return false
+	}
+	sig, err := schnorr.ParseSignature(sb)
+	if err != nil {
+		return false
+	}
+	return sig.Verify(delegationHash(delegateePub, conditions), pub)
+}
+
+// signEvent signs ev with the profile's private key. When the profile is a
+// delegated one, the delegation conditions are enforced and the delegation
+// tag is attached before signing.
+func (cfg *Config) signEvent(ev *nostr.Event) error {
+	var sk string
+	if _, s, err := nip19.Decode(cfg.PrivateKey); err == nil {
+		sk = s.(string)
+	} else {
+		return err
+	}
+	if d := cfg.Delegation; d != nil {
+		c, err := parseDelegationConditions(d.Conditions)
+		if err != nil {
+			return err
+		}
+		createdAt := ev.CreatedAt
+		if createdAt == 0 {
+			createdAt = nostr.Now()
+			ev.CreatedAt = createdAt
+		}
+		if err := c.allow(ev.Kind, int64(createdAt)); err != nil {
+			return err
+		}
+		ev.Tags = append(ev.Tags, nostr.Tag{"delegation", d.Delegator, d.Conditions, d.Token})
+	}
+	return ev.Sign(sk)
+}
+
+// delegationDisplayPubKey returns the delegator's public key when ev carries
+// a valid NIP-26 delegation tag, otherwise the event's own public key.
+func delegationDisplayPubKey(ev *nostr.Event) (string, bool) {
+	tag := ev.Tags.GetFirst([]string{"delegation"})
+	if tag == nil || len(*tag) < 4 {
+		return ev.PubKey, false
+	}
+	delegator, conditions, token := (*tag)[1], (*tag)[2], (*tag)[3]
+	c, err := parseDelegationConditions(conditions)
+	if err != nil {
+		return ev.PubKey, false
+	}
+	if err := c.allow(ev.Kind, int64(ev.CreatedAt)); err != nil {
+		return ev.PubKey, false
+	}
+	if !verifyDelegationToken(delegator, ev.PubKey, conditions, token) {
+		return ev.PubKey, false
+	}
+	return delegator, true
+}
+
+func delegationCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "delegation",
+		Usage: "manage NIP-26 delegated signing",
+		Subcommands: []*cli.Command{
+			{
+				Name: "create",
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "profile", Usage: "profile name to create for the delegatee"},
+					&cli.StringFlag{Name: "kinds", Value: "1,6,7", Usage: "comma separated kinds to permit"},
+					&cli.IntFlag{Name: "days", Value: 30, Usage: "days until the delegation expires"},
+					&cli.StringFlag{Name: "delegatee", Usage: "npub of an external delegatee (print token as JSON instead of creating a profile)"},
+				},
+				Usage:     "delegate signing to a new keypair",
+				UsageText: "algia delegation create --profile [name]",
+				HelpName:  "create",
+				Action:    doDelegationCreate,
+			},
+			{
+				Name:      "show",
+				Usage:     "show delegation status of current profile",
+				UsageText: "algia -a [name] delegation show",
+				HelpName:  "show",
+				Action:    doDelegationShow,
+			},
+			{
+				Name:      "import",
+				Usage:     "import delegation JSON from stdin into current profile",
+				UsageText: "algia -a [name] delegation import < delegation.json",
+				HelpName:  "import",
+				Action:    doDelegationImport,
+			},
+		},
+	}
+}
+
+func doDelegationCreate(cCtx *cli.Context) error {
+	cfg := cCtx.App.Metadata["config"].(*Config)
+	if cfg.Delegation != nil {
+		return errors.New("current profile is already delegated: cannot delegate again")
+	}
+
+	var delegatorSk string
+	if _, s, err := nip19.Decode(cfg.PrivateKey); err == nil {
+		delegatorSk = s.(string)
+	} else {
+		return err
+	}
+	delegatorPub, err := nostr.GetPublicKey(delegatorSk)
+	if err != nil {
+		return err
+	}
+
+	days := cCtx.Int("days")
+	if days <= 0 {
+		return errors.New("--days must be positive")
+	}
+	conditions := []string{}
+	for _, s := range strings.Split(cCtx.String("kinds"), ",") {
+		kind, err := strconv.Atoi(strings.TrimSpace(s))
+		if err != nil {
+			return fmt.Errorf("invalid kind %q", s)
+		}
+		conditions = append(conditions, fmt.Sprintf("kind=%d", kind))
+	}
+	now := time.Now().Unix()
+	conditions = append(conditions,
+		fmt.Sprintf("created_at>%d", now),
+		fmt.Sprintf("created_at<%d", now+int64(days)*86400))
+	conds := strings.Join(conditions, "&")
+
+	var delegateePub, delegateeNsec string
+	if npub := cCtx.String("delegatee"); npub != "" {
+		if prefix, s, err := nip19.Decode(npub); err == nil && prefix == "npub" {
+			delegateePub = s.(string)
+		} else {
+			return fmt.Errorf("invalid delegatee %q", npub)
+		}
+	} else {
+		delegateeSk := nostr.GeneratePrivateKey()
+		if delegateePub, err = nostr.GetPublicKey(delegateeSk); err != nil {
+			return err
+		}
+		if delegateeNsec, err = nip19.EncodePrivateKey(delegateeSk); err != nil {
+			return err
+		}
+	}
+
+	token, err := createDelegationToken(delegatorSk, delegateePub, conds)
+	if err != nil {
+		return err
+	}
+	delegation := Delegation{
+		Delegator:  delegatorPub,
+		Conditions: conds,
+		Token:      token,
+	}
+
+	// External delegatee: print the delegation for `delegation import`
+	if delegateeNsec == "" {
+		return json.NewEncoder(os.Stdout).Encode(delegation)
+	}
+
+	profile := cCtx.String("profile")
+	if profile == "" {
+		return errors.New("--profile is required")
+	}
+	dir, err := configDir()
+	if err != nil {
+		return err
+	}
+	fp := filepath.Join(dir, "algia", "config-"+profile+".json")
+	if _, err := os.Stat(fp); err == nil {
+		return fmt.Errorf("profile already exists: %s", fp)
+	}
+
+	ncfg := Config{
+		Relays:     cfg.Relays,
+		FollowList: cfg.FollowList,
+		Updated:    cfg.Updated,
+		PrivateKey: delegateeNsec,
+		Delegation: &delegation,
+	}
+	if err := ncfg.saveConfig(profile); err != nil {
+		return err
+	}
+
+	delegateeNpub, _ := nip19.EncodePublicKey(delegateePub)
+	delegatorNpub, _ := nip19.EncodePublicKey(delegatorPub)
+	fmt.Println("delegatee:", delegateeNpub)
+	fmt.Println("delegator:", delegatorNpub)
+	fmt.Println("conditions:", conds)
+	fmt.Println("wrote", fp)
+	return nil
+}
+
+func doDelegationShow(cCtx *cli.Context) error {
+	cfg := cCtx.App.Metadata["config"].(*Config)
+	d := cfg.Delegation
+	if d == nil {
+		fmt.Println("no delegation configured for this profile")
+		return nil
+	}
+
+	if npub, err := nip19.EncodePublicKey(d.Delegator); err == nil {
+		fmt.Println("delegator:", npub)
+	} else {
+		fmt.Println("delegator:", d.Delegator)
+	}
+
+	c, err := parseDelegationConditions(d.Conditions)
+	if err != nil {
+		return err
+	}
+	kinds := []string{}
+	for _, k := range c.kinds {
+		kinds = append(kinds, strconv.Itoa(k))
+	}
+	fmt.Println("kinds:", strings.Join(kinds, ", "))
+	if c.before != 0 {
+		expire := time.Unix(c.before, 0)
+		if left := time.Until(expire); left > 0 {
+			fmt.Printf("expires: %v (%d days left)\n", expire, int(left.Hours()/24))
+		} else {
+			fmt.Printf("expires: %v (EXPIRED)\n", expire)
+		}
+	} else {
+		fmt.Println("expires: never")
+	}
+
+	var delegateePub string
+	if _, s, err := nip19.Decode(cfg.PrivateKey); err == nil {
+		if delegateePub, err = nostr.GetPublicKey(s.(string)); err != nil {
+			return err
+		}
+	} else {
+		return err
+	}
+	if verifyDelegationToken(d.Delegator, delegateePub, d.Conditions, d.Token) {
+		fmt.Println("token: valid")
+	} else {
+		fmt.Println("token: INVALID")
+	}
+	return nil
+}
+
+func doDelegationImport(cCtx *cli.Context) error {
+	cfg := cCtx.App.Metadata["config"].(*Config)
+	profile := cCtx.App.Metadata["profile"].(string)
+
+	var d Delegation
+	if err := json.NewDecoder(os.Stdin).Decode(&d); err != nil {
+		return err
+	}
+	if _, err := parseDelegationConditions(d.Conditions); err != nil {
+		return err
+	}
+	var delegateePub string
+	if _, s, err := nip19.Decode(cfg.PrivateKey); err == nil {
+		if delegateePub, err = nostr.GetPublicKey(s.(string)); err != nil {
+			return err
+		}
+	} else {
+		return err
+	}
+	if !verifyDelegationToken(d.Delegator, delegateePub, d.Conditions, d.Token) {
+		return errors.New("delegation token is not valid for this profile's key")
+	}
+	cfg.Delegation = &d
+	if err := cfg.saveConfig(profile); err != nil {
+		return err
+	}
+	fmt.Println("delegation imported")
+	return nil
+}

--- a/nip26_test.go
+++ b/nip26_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/nbd-wtf/go-nostr/nip19"
+)
+
+// Test vectors from NIP-26
+const (
+	testDelegatorSk  = "ee35e8bb71131c02c1d7e73231daa48e9953d329a4b701f7133c8f46dd21139c"
+	testDelegatorPub = "8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd"
+	testDelegateeSk  = "777e4f60b4aa87937e13acc84f7abcc3c93cc035cb4c1e9f7a9086dd78fffce1"
+	testDelegateePub = "477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396"
+	testConditions   = "kind=1&created_at>1674834236&created_at<1677426236"
+	testToken        = "6f44d7fe4f1c09f3954640fb58bd12bae8bb8ff4120853c4693106c82e920e2b898f1f9ba9bd65449a987c39c0423426ab7b53910c0c6abfb41b30bc16e5f524"
+)
+
+func TestVerifyDelegationTokenSpecExample(t *testing.T) {
+	if !verifyDelegationToken(testDelegatorPub, testDelegateePub, testConditions, testToken) {
+		t.Fatal("spec example token should verify")
+	}
+	if verifyDelegationToken(testDelegatorPub, testDelegateePub, "kind=1&kind=4&created_at>1674834236&created_at<1677426236", testToken) {
+		t.Fatal("token must not verify against tampered conditions")
+	}
+	if verifyDelegationToken(testDelegatorPub, testDelegatorPub, testConditions, testToken) {
+		t.Fatal("token must not verify against a different delegatee")
+	}
+}
+
+func TestCreateDelegationToken(t *testing.T) {
+	token, err := createDelegationToken(testDelegatorSk, testDelegateePub, testConditions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifyDelegationToken(testDelegatorPub, testDelegateePub, testConditions, token) {
+		t.Fatal("created token should verify")
+	}
+}
+
+func TestParseDelegationConditions(t *testing.T) {
+	c, err := parseDelegationConditions(testConditions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.kinds) != 1 || c.kinds[0] != 1 {
+		t.Fatalf("kinds = %v, want [1]", c.kinds)
+	}
+	if c.after != 1674834236 || c.before != 1677426236 {
+		t.Fatalf("range = %d..%d", c.after, c.before)
+	}
+
+	if err := c.allow(1, 1675000000); err != nil {
+		t.Fatalf("kind 1 in range should be allowed: %v", err)
+	}
+	if err := c.allow(4, 1675000000); err == nil {
+		t.Fatal("kind 4 should not be allowed")
+	}
+	if err := c.allow(1, 1674834236); err == nil {
+		t.Fatal("created_at at lower bound should not be allowed")
+	}
+	if err := c.allow(1, 1677426236); err == nil {
+		t.Fatal("created_at at upper bound should not be allowed")
+	}
+
+	if _, err := parseDelegationConditions("kind=1&foo=2"); err == nil {
+		t.Fatal("unsupported condition should be rejected")
+	}
+}
+
+func TestSignEventWithDelegation(t *testing.T) {
+	nsec, err := nip19.EncodePrivateKey(testDelegateeSk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &Config{
+		PrivateKey: nsec,
+		Delegation: &Delegation{
+			Delegator:  testDelegatorPub,
+			Conditions: testConditions,
+			Token:      testToken,
+		},
+	}
+
+	ev := nostr.Event{
+		Kind:      1,
+		CreatedAt: nostr.Timestamp(1675000000),
+		Content:   "Hello, world!",
+		Tags:      nostr.Tags{},
+	}
+	if err := cfg.signEvent(&ev); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := ev.CheckSignature(); !ok || err != nil {
+		t.Fatalf("signature check failed: %v", err)
+	}
+	if ev.PubKey != testDelegateePub {
+		t.Fatalf("event pubkey = %s, want delegatee", ev.PubKey)
+	}
+	tag := ev.Tags.GetFirst([]string{"delegation"})
+	if tag == nil || len(*tag) != 4 {
+		t.Fatal("delegation tag not attached")
+	}
+
+	pubkey, delegated := delegationDisplayPubKey(&ev)
+	if !delegated || pubkey != testDelegatorPub {
+		t.Fatalf("display pubkey = %s (delegated=%v), want delegator", pubkey, delegated)
+	}
+
+	// disallowed kind must be refused before signing
+	bad := nostr.Event{
+		Kind:      4,
+		CreatedAt: nostr.Timestamp(1675000000),
+		Tags:      nostr.Tags{},
+	}
+	if err := cfg.signEvent(&bad); err == nil {
+		t.Fatal("kind 4 should be refused by delegation conditions")
+	}
+
+	// expired delegation must be refused
+	expired := nostr.Event{
+		Kind:      1,
+		CreatedAt: nostr.Timestamp(1677426300),
+		Tags:      nostr.Tags{},
+	}
+	if err := cfg.signEvent(&expired); err == nil {
+		t.Fatal("expired delegation should be refused")
+	}
+}
+
+func TestSignEventWithoutDelegation(t *testing.T) {
+	nsec, err := nip19.EncodePrivateKey(testDelegateeSk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &Config{PrivateKey: nsec}
+	ev := nostr.Event{
+		Kind:      1,
+		CreatedAt: nostr.Now(),
+		Content:   "plain",
+		Tags:      nostr.Tags{},
+	}
+	if err := cfg.signEvent(&ev); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := ev.CheckSignature(); !ok || err != nil {
+		t.Fatalf("signature check failed: %v", err)
+	}
+	if ev.Tags.GetFirst([]string{"delegation"}) != nil {
+		t.Fatal("delegation tag must not be attached without delegation")
+	}
+	if _, delegated := delegationDisplayPubKey(&ev); delegated {
+		t.Fatal("plain event must not be treated as delegated")
+	}
+}

--- a/profile.go
+++ b/profile.go
@@ -164,16 +164,9 @@ func doUpdateProfile(cCtx *cli.Context) error {
 	}
 	ev.Content = string(b)
 
-	var sk string
-	if _, s, err := nip19.Decode(cfg.PrivateKey); err == nil {
-		sk = s.(string)
-	} else {
-		return err
-	}
-
 	clientTag(ev)
 	ev.CreatedAt = nostr.Now()
-	if err := ev.Sign(sk); err != nil {
+	if err := cfg.signEvent(ev); err != nil {
 		return err
 	}
 

--- a/timeline.go
+++ b/timeline.go
@@ -92,7 +92,7 @@ type postArg struct {
 }
 
 func callPost(arg *postArg) error {
-	sk, pub, err := getSkAndPub(arg.cfg)
+	_, pub, err := getSkAndPub(arg.cfg)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func callPost(arg *postArg) error {
 	if err != nil {
 		return err
 	}
-	if err := ev.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(ev); err != nil {
 		return err
 	}
 
@@ -185,7 +185,7 @@ func doEvent(cCtx *cli.Context) error {
 	ev.Kind = kind
 	ev.CreatedAt = nostr.Now()
 
-	if err := ev.Sign(sk); err != nil {
+	if err := cfg.signEvent(&ev); err != nil {
 		return err
 	}
 
@@ -218,7 +218,7 @@ func doReply(cCtx *cli.Context) error {
 	}
 
 	cfg := cCtx.App.Metadata["config"].(*Config)
-	sk, pub, err := getSkAndPub(cfg)
+	_, pub, err := getSkAndPub(cfg)
 	if err != nil {
 		return err
 	}
@@ -254,7 +254,7 @@ func doReply(cCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := ev.Sign(sk); err != nil {
+	if err := cfg.signEvent(ev); err != nil {
 		return err
 	}
 
@@ -326,7 +326,7 @@ func doUnrepost(cCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := ev.Sign(sk); err != nil {
+	if err := cfg.signEvent(ev); err != nil {
 		return err
 	}
 
@@ -365,7 +365,7 @@ type likeArg struct {
 }
 
 func callLike(arg *likeArg) error {
-	sk, pub, err := getSkAndPub(arg.cfg)
+	_, pub, err := getSkAndPub(arg.cfg)
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func callLike(arg *likeArg) error {
 	if err != nil {
 		return err
 	}
-	if err := ev.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(ev); err != nil {
 		return err
 	}
 
@@ -481,7 +481,7 @@ func callUnlike(arg *unlikeArg) error {
 		return fmt.Errorf("failed to parse event from '%s'", arg.id)
 	}
 
-	sk, pub, err := getSkAndPub(arg.cfg)
+	_, pub, err := getSkAndPub(arg.cfg)
 	if err != nil {
 		return err
 	}
@@ -509,7 +509,7 @@ func callUnlike(arg *unlikeArg) error {
 	if err != nil {
 		return err
 	}
-	if err := ev.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(ev); err != nil {
 		return err
 	}
 
@@ -791,7 +791,7 @@ func doStream(cCtx *cli.Context) error {
 			evr.Tags = evr.Tags.AppendUnique(nostr.Tag{"e", ev.ID, "", "reply"})
 			evr.CreatedAt = ev.CreatedAt + 1
 			evr.Kind = ev.Kind
-			if err := evr.Sign(sk); err != nil {
+			if err := cfg.signEvent(&evr); err != nil {
 				return err
 			}
 			cfg.Do(context.Background(), Relay{Write: true}, func(ctx context.Context, relay *nostr.Relay) bool {
@@ -913,7 +913,7 @@ func postMsg(cCtx *cli.Context, msg string) error {
 	ev.Kind = nostr.KindTextNote
 	ev.Tags = nostr.Tags{}
 	clientTag(&ev)
-	if err := ev.Sign(sk); err != nil {
+	if err := cfg.signEvent(&ev); err != nil {
 		return err
 	}
 
@@ -958,7 +958,7 @@ func callReply(arg *replyArg) error {
 		return fmt.Errorf("failed to parse event from '%s'", id)
 	}
 
-	sk, pub, err := getSkAndPub(arg.cfg)
+	_, pub, err := getSkAndPub(arg.cfg)
 	if err != nil {
 		return err
 	}
@@ -971,7 +971,7 @@ func callReply(arg *replyArg) error {
 	if err != nil {
 		return err
 	}
-	if err := ev.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(ev); err != nil {
 		return err
 	}
 
@@ -1000,7 +1000,7 @@ type repostArg struct {
 func callRepost(arg *repostArg) error {
 	id := arg.id
 
-	sk, pub, err := getSkAndPub(arg.cfg)
+	_, pub, err := getSkAndPub(arg.cfg)
 	if err != nil {
 		return err
 	}
@@ -1023,7 +1023,7 @@ func callRepost(arg *repostArg) error {
 	if err != nil {
 		return err
 	}
-	if err := ev.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(ev); err != nil {
 		return err
 	}
 
@@ -1057,7 +1057,7 @@ func callUnrepost(arg *unrepostArg) error {
 		return fmt.Errorf("failed to parse event from '%s'", id)
 	}
 
-	sk, pub, err := getSkAndPub(arg.cfg)
+	_, pub, err := getSkAndPub(arg.cfg)
 	if err != nil {
 		return err
 	}
@@ -1085,7 +1085,7 @@ func callUnrepost(arg *unrepostArg) error {
 	if err != nil {
 		return err
 	}
-	if err := ev.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(ev); err != nil {
 		return err
 	}
 
@@ -1123,7 +1123,7 @@ func callDelete(arg *deleteArg) error {
 		return fmt.Errorf("failed to parse event from '%s'", id)
 	}
 
-	sk, pub, err := getSkAndPub(arg.cfg)
+	_, pub, err := getSkAndPub(arg.cfg)
 	if err != nil {
 		return err
 	}
@@ -1132,7 +1132,7 @@ func callDelete(arg *deleteArg) error {
 	if err != nil {
 		return err
 	}
-	if err := ev.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(ev); err != nil {
 		return err
 	}
 
@@ -1294,7 +1294,7 @@ func callReport(arg *reportArg) error {
 		report.Tags = append(report.Tags, nostr.Tag{"e", targetEventID})
 	}
 
-	if err := report.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(report); err != nil {
 		return err
 	}
 
@@ -1416,7 +1416,7 @@ func callReportProfile(arg *reportProfileArg) error {
 		report.Tags = append(report.Tags, nostr.Tag{"p", targetPubkey})
 	}
 
-	if err := report.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(report); err != nil {
 		return err
 	}
 

--- a/zap.go
+++ b/zap.go
@@ -268,7 +268,7 @@ func callZap(arg *zapArg) error {
 	zr.Kind = nostr.KindZapRequest // 9734
 	zr.CreatedAt = nostr.Now()
 	zr.Content = arg.comment
-	if err := zr.Sign(sk); err != nil {
+	if err := arg.cfg.signEvent(&zr); err != nil {
 		return err
 	}
 	b, err := zr.MarshalJSON()


### PR DESCRIPTION
This adds NIP-26 support so that a profile can post with a disposable key while the root key stays offline.

`algia delegation create --profile blog --kinds 1,6,7 --days 30` generates a delegatee keypair, signs a delegation token with the current profile's key and writes a new profile whose config carries the delegatee nsec plus the delegation (delegator pubkey, conditions, token). Everything posted via `-a blog` is then signed by the delegatee with the delegation tag attached. For a key held on another machine, `create --delegatee <npub>` prints the token as JSON and `delegation import` installs it into the profile that owns that key, so the root nsec never has to touch the posting machine. `delegation show` displays the delegator, permitted kinds, expiry and token validity.

All user-identity signing now goes through a `signEvent` helper that enforces the delegation conditions before signing; a kind outside the delegation or an expired window fails with a clear error instead of publishing an event other relays would reject. Transport-level signatures (NIP-42 auth, NIP-98 headers, NIP-59 seals, NWC requests) are intentionally left as direct signs. When rendering events, a valid delegation tag is verified and the note is attributed to the delegator with a `(delegated)` marker.

Tests use the example keys and token from the NIP-26 spec to cover token creation/verification, condition parsing and boundary checks, tag attachment and rejection. Verified end-to-end against a local cagliostr instance (with mattn/cagliostr#11 applied): a delegated post is accepted and displayed as the delegator's note.